### PR TITLE
Make the Google Calendar ID secret

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -27,6 +27,7 @@ jobs:
       - name: Run the synchronization
         env:
           VERKADA_API_KEY: ${{ secrets.VERKADA_API_KEY }}
+          GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
         run: |
           python src/main.py \
               --verbose \

--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ following command line arguments:
 
 * `--config FILE`: the path name to the INI config file.
 * `--google-creds`: the path name to the Google credentials file.
+* `--google-calendar-id`: the ID of the Google Calendar to synchronize.
+  * **NOTE:** Alternatively, this value can be passed via the
+    `GOOGLE_CALENDAR_ID` environment variable (so that it is not visible
+    in process listings).
 * `--verkada-api-key`: the Verkada API key.
   * **NOTE:** Alternatively, this value can be passed via the
     `VERKADA_API_KEY` environment variable (so that it is not visible
@@ -202,6 +206,8 @@ key and the Google credentials file.  For example:
 1. Under "Repository secrets", click "New repository secret".
    1. Create a secret named `VERKADA_API_KEY`.
    1. Paste in the Verkada API key.
+1. Repeat the procedure, pasting in the contents of the Google
+   Calendar ID.
 1. Repeat the procedure, pasting in the contents of the Google
    credentials file.
    1. It is recomended to store the base64-encoded version of your

--- a/src/GoogleCalendar.py
+++ b/src/GoogleCalendar.py
@@ -16,7 +16,7 @@ def login(args):
     return build("calendar", "v3", credentials=creds,
                  cache_discovery=False)
 
-def download(service, config):
+def download(service, args, config):
     first_date = datetime.combine(config['first date'],
                                   time(0, 0, 0),
                                   tzinfo=timezone.utc).isoformat()
@@ -30,7 +30,7 @@ def download(service, config):
     while True:
         events_result = (
             service.events()
-            .list(calendarId=config['google calendar id'],
+            .list(calendarId=args.google_calendar_id,
                   timeMin=first_date,
                   timeMax=last_date,
                   # Expand recurring events into separate instances rather
@@ -68,7 +68,7 @@ def download(service, config):
 
     return output
 
-def add(verkada_event, service, config):
+def add(verkada_event, service, args, config):
     logging.info(f"Adding Google Calendar event: {verkada_event['name']} / {verkada_event['door_status']}, starting {verkada_event['start_time']}")
 
     color = config[f'color {verkada_event["door_status"]}']
@@ -85,11 +85,11 @@ def add(verkada_event, service, config):
         "colorId": color,
     }
 
-    service.events().insert(calendarId=config['google calendar id'],
+    service.events().insert(calendarId=args.google_calendar_id,
                             body=google_event).execute()
 
-def delete(google_event, service, config):
+def delete(google_event, service, args, config):
     logging.info(f"Removing Google Calendar event: {google_event['summary']} / {google_event['description']}, starting {google_event['start']}")
 
-    service.events().delete(calendarId=config['google calendar id'],
+    service.events().delete(calendarId=args.google_calendar_id,
                             eventId=google_event["id"]).execute()

--- a/src/main.py
+++ b/src/main.py
@@ -31,6 +31,13 @@ def setup_cli():
                         required=True,
                         help='Google credentials JSON file')
 
+    default_val = os.environ.get("GOOGLE_CALENDAR_ID", None)
+    required_val = False if default_val else True
+    parser.add_argument('--google-calendar-id',
+                        default=default_val,
+                        required=required_val,
+                        help='Google Calendar ID')
+
     # TODO: This functionality is currently unimplemented.
     # Intent: Load the "regular" schedule from a JSON file because
     # -- as of May 2025 -- there's no Verkada API to download that
@@ -142,7 +149,7 @@ def main():
     # Get a dictionary of door names, each containing a sorted list of
     # events starting from 5 days ago.
     google_service = GoogleCalendar.login(args)
-    google_events = GoogleCalendar.download(google_service, config)
+    google_events = GoogleCalendar.download(google_service, args, config)
 
     verkada_service = Verkada.login(args)
     # Get a listing of sites (which contain timezone information).
@@ -184,10 +191,10 @@ def main():
         # Update the calendar
         for event in to_delete:
             logging.debug(event)
-            GoogleCalendar.delete(event, google_service, config)
+            GoogleCalendar.delete(event, google_service, args, config)
         for event in to_add:
             logging.debug(event)
-            GoogleCalendar.add(event, google_service, config)
+            GoogleCalendar.add(event, google_service, args, config)
         logging.info("Finished synchronizing Google calendar and Verkada calendars")
 
 if __name__ == "__main__":


### PR DESCRIPTION
It's probably not *that* secret, but there's really no reason to make it public, either.  So let's go ahead and make it secret.