### PR TITLE
Verkada.py: improve timezone handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ Click "+ Add" to create a new key:
   1. Door Access Management: All Selected
   1. Core Command: Read-Only
   1. Cameras: Read-Only
+     * **NOTE:** VerCalBot needs read-only access to the cameras to
+       obtain site timezone information.  This was needed when the
+       code was originally written (early 2025), but the Verakda API
+       evolved and this is no longer necessary.  However, the code has
+       not yet been updated to *not* read the camera timezone
+       information.  At some point, that
+       read-the-timezone-from-the-cameras code will be removed.  But
+       until then, read-only camera access for the API key is still
+       necessary.
 * Select an expiration date
 * Click "Generate API"
 

--- a/src/Verkada.py
+++ b/src/Verkada.py
@@ -87,7 +87,10 @@ def get_sites(session):
     output = {}
     for camera in cameras:
         site_id = camera['site_id']
-        if site_id not in output:
+        # It is possible for a camera to be not yet deployed, and
+        # therefore have its site_id be None (and no timezone).  So --
+        # skip those.
+        if site_id and site_id not in output:
             tz = zoneinfo.ZoneInfo(camera['timezone'])
             output[site_id] = tz
 
@@ -112,6 +115,15 @@ def get_doors(session, sites):
     # sites data.
     output = {}
     for door in all_doors:
+        # When this code was originally written (early 2025), the door
+        # objects did not contain timezones.  As of June 2025, doors
+        # now have a "timezone" attribute.  So we'll use that.  But on
+        # the off chance that they don't, fall back to the old method
+        # of getting the timezone from the site.
+        if 'timezone' in door:
+            door['PYTZ'] = zoneinfo.ZoneInfo(door['timezone'])
+            continue
+
         sid = door['site']['site_id']
         if sid in sites:
             # Use an upper case key so that we know we put it there


### PR DESCRIPTION
* When this code was originally written (early 2025), the door objects did not contain timezones.  As of June 2025, doors now have a "timezone" attribute.  So we'll use that.  But on the off chance that they don't, fall back to the old method of getting the timezone from the site.
* Also, when loading timezones from cameras, it's possible that a camera hasn't been deployed yet, and therefor has "None" for the site and timezone. So -- skip those.